### PR TITLE
Removed the .to_json on the body of http_requests

### DIFF
--- a/lib/ct_register_microservice/control_tower.rb
+++ b/lib/ct_register_microservice/control_tower.rb
@@ -35,7 +35,7 @@ module CtRegisterMicroservice
         name: CtRegisterMicroservice.config.name,
         url: CtRegisterMicroservice.config.url,
         active: !!active
-      }
+      }.to_json
       result = make_call(options)
       result
     end

--- a/lib/ct_register_microservice/http_service.rb
+++ b/lib/ct_register_microservice/http_service.rb
@@ -13,6 +13,7 @@ module CtRegisterMicroservice
       headers = options.headers || {}
       headers['Content-Type'] = 'application/json' if options.http_method == 'post' || options.http_method == 'put'
       endpoint = Endpoint.new(options, credentials).get
+      body = options.body
 
       case http_method
       when :get
@@ -22,17 +23,17 @@ module CtRegisterMicroservice
       when :post
         response = HTTParty.post(url+endpoint, {
           headers: headers,
-          body: options.body.to_json
+          body: body
         })
       when :put
         response = HTTParty.put(url+endpoint, {
           headers: headers,
-          body: options.body.to_json
+          body: body
         })
       when :patch
         response = HTTParty.patch(url+endpoint, {
           headers: headers,
-          body: options.body.to_json
+          body: body
         })
       end
 

--- a/spec/cases/ct_register_microservice_control_tower_register_spec.rb
+++ b/spec/cases/ct_register_microservice_control_tower_register_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "CtRegisterMicroservice::ControlTower register" do
         name: 'Test',
         url: 'http://my-microservice-url.com',
         active: true
-      }.to_json,
+      },
       headers: {
         'Content-Type' => 'application/json'
       }

--- a/spec/cases/ct_register_microservice_control_tower_request_spec.rb
+++ b/spec/cases/ct_register_microservice_control_tower_request_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "CtRegisterMicroservice::ControlTower request" do
     request_content = {
       body: {
         foo: 'bar'
-      }.to_json,
+      },
       headers: {
         'Authentication' => 'token'
       }
@@ -65,7 +65,7 @@ RSpec.describe "CtRegisterMicroservice::ControlTower request" do
     request_content = {
       body: {
         foo: 'bar'
-      }.to_json,
+      },
       headers: {
         'Authentication' => 'token'
       }
@@ -88,7 +88,7 @@ RSpec.describe "CtRegisterMicroservice::ControlTower request" do
     request_content = {
       body: {
         foo: 'bar'
-      }.to_json,
+      },
       headers: {
         'Authentication' => 'token'
       }


### PR DESCRIPTION
The body was being transformed into json before the PUT, PATCH and POST requests.
We should pay attention to where this is used in other projects, as it might impact them.